### PR TITLE
use regexp for multiple keys

### DIFF
--- a/src/__tests__/__snapshots__/macro.test.js.snap
+++ b/src/__tests__/__snapshots__/macro.test.js.snap
@@ -64,6 +64,30 @@ const variable = 'defaultStringValue';
 "
 `;
 
+exports[`penv.macro # with config macros should replace the environment variable to the matched value via regexp: should replace the environment variable to the matched value via regexp 1`] = `
+"
+import env from '../../macro';
+
+const variable = env({
+  development: 'development',
+  staging: 'staging',
+  production: 'production',
+  [/^(test|production)$/]: () => {
+    console.log('test');
+    
+    return 'test';
+  }
+});
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const variable = () => {
+  console.log('test');
+  return 'test';
+};
+"
+`;
+
 exports[`penv.macro # with config macros should replace the environment variable to the matched value: should replace the environment variable to the matched value 1`] = `
 "
 import env from '../../macro';
@@ -165,6 +189,30 @@ const variable = inlineEnv({
       ↓ ↓ ↓ ↓ ↓ ↓
 
 const variable = 'defaultStringValue';
+"
+`;
+
+exports[`penv.macro # without config macros should replace the environment variable to the matched value via regexp: should replace the environment variable to the matched value via regexp 1`] = `
+"
+import env from '../../macro';
+
+const variable = env({
+  development: 'development',
+  staging: 'staging',
+  production: 'production',
+  [/^(test|production)$/]: () => {
+    console.log('test');
+    
+    return 'test';
+  }
+});
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const variable = () => {
+  console.log('test');
+  return 'test';
+};
 "
 `;
 

--- a/src/__tests__/helpers/create-tests.js
+++ b/src/__tests__/helpers/create-tests.js
@@ -26,6 +26,23 @@ export default function createTestsForPenvMacro({plugin}) {
         `,
       },
 
+      'should replace the environment variable to the matched value via regexp': {
+        code: `
+          import env from '../../macro';
+
+          const variable = env({
+            development: 'development',
+            staging: 'staging',
+            production: 'production',
+            [/^(test|production)$/]: () => {
+              console.log('test');
+              
+              return 'test';
+            }
+          });
+        `,
+      },
+
       'should use `null` as default value if no relevant value was matched': {
         code: `
           import inlineEnv from '../../macro';

--- a/src/macro.js
+++ b/src/macro.js
@@ -14,7 +14,11 @@ function envVariableMacro({references, babel: {types: t}, config}) {
     const matchedPropertyPath = argumentPath
       .get('properties')
       .find(propertyPath => {
-        const keyName = propertyPath.get('key').node.name
+        const node = propertyPath.get('key').node
+        if (t.isRegExpLiteral(node))
+          return new RegExp(node.pattern).test(targetEnv)
+
+        const keyName = node.name
 
         return keyName === targetEnv
       })


### PR DESCRIPTION
🚀🚀
usage like this:

```js
const base = penv({
  [/qatest|production|/]: 'https://example.com'
})
```
using regularization can provide a flexible and simple combination scheme to solve the problem of multiple keys or fuzzy matching.

if u accept this pr.